### PR TITLE
fix: Fix compilation for Xcode 14.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,7 +14,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "10bc670db657d11bdd561e07de30a9041311b2b1",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     },
@@ -23,17 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-parsing",
       "state" : {
-        "revision" : "bc92e84968990b41640214b636667f35b6e5d44c",
-        "version" : "0.10.0"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
-        "version" : "0.3.3"
+        "revision" : "4bb9192468c1a8be57f46b7d6fd4f561c88b2195",
+        "version" : "0.11.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,10 +19,10 @@ let package = Package(
     ],
     dependencies: [
         // Source code dependencies
-        .package(url: "https://github.com/pointfreeco/swift-parsing", exact: "0.10.0"),
+        .package(url: "https://github.com/pointfreeco/swift-parsing", exact: "0.11.0"),
 
         // Plugins
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SemanticVersioning.swift
+++ b/Sources/SemanticVersioning.swift
@@ -180,14 +180,12 @@ extension SemanticVersion {
         let patch: Int
         
         internal static let parser:  AnyParser<Substring, SemanticVersion.Core> = {
-            Parse {
-                Int.parser()
+            Parse(Core.init) {
+                Int.parser(of: Substring.self)
                 "."
-                Int.parser()
+                Int.parser(of: Substring.self)
                 "."
-                Int.parser()
-            }.map {
-                return Core(major: $0, minor: $1, patch: $2)
+                Int.parser(of: Substring.self)
             }.eraseToAnyParser()
         }()
     }


### PR DESCRIPTION
After upgrading to Xcode 14.3 the tool does not build correctly any longer. This PR fixes it by:

1. Updating dependencies 
2. Fixing ambiguous usage or `Parsing` methods